### PR TITLE
Add dotnet-srcset project

### DIFF
--- a/input/data/projects/dotnet-srcset.yml
+++ b/input/data/projects/dotnet-srcset.yml
@@ -1,0 +1,9 @@
+Title: dotnet-srcset
+Source: https://github.com/stevedesmond-ca/dotnet-srcset
+Language: C#
+GlobalTool: srcset
+NuGet: 
+  - dotnet-srcset
+Tags:
+  - Global Tool
+  - Graphics


### PR DESCRIPTION
This adds the recently renamed `dotnet-srcset` (previously `ImageResizer`, though not the one already on discoverdot.net) -- I wasn't sure how to easily find the max `DiscoveryDate` so I just left it out.