### PR TITLE
Specify user-agent in httpClient usage

### DIFF
--- a/config.wyam
+++ b/config.wyam
@@ -614,6 +614,7 @@ public async Task<IEnumerable<IDocument>> GetProjectGitHubData(IReadOnlyList<IDo
     string foundationReadme;
 	using (HttpClient httpClient = new HttpClient())
 	{
+        httpClient.DefaultRequestHeaders.Add("User-Agent", "Discoverdot.net build process");
 		foundationReadme = await httpClient.GetStringAsync("https://raw.githubusercontent.com/dotnet/home/master/README.md");
 	}
 
@@ -872,6 +873,8 @@ public async Task<IEnumerable<IDocument>> GetFeedData(IReadOnlyList<IDocument> i
                     List<ISyndicationItem> items = new List<ISyndicationItem>();
                     using (HttpClient httpClient = new HttpClient())
                     {
+                        httpClient.DefaultRequestHeaders.Add("User-Agent", "Discoverdot.net build process");
+
                         using (Stream stream = await httpClient.GetStreamAsync(feed))
                         {
                             using (StreamReader streamReader = new XmlStreamReader(stream))
@@ -1158,6 +1161,7 @@ public async Task<IEnumerable<IDocument>> GetMeetupData(IReadOnlyList<IDocument>
 	List<MeetupGroup> groups = new List<MeetupGroup>();
 	using (HttpClient httpClient = new HttpClient())
 	{
+        httpClient.DefaultRequestHeaders.Add("User-Agent", "Discoverdot.net build process");
 		int offset = 0;
 		while (true)
 		{
@@ -1186,6 +1190,7 @@ public async Task<IEnumerable<IDocument>> GetMeetupData(IReadOnlyList<IDocument>
     // Process input documents    
 	using (HttpClient httpClient = new HttpClient())
 	{
+        httpClient.DefaultRequestHeaders.Add("User-Agent", "Discoverdot.net build process");
         foreach(IDocument input in inputs)
         {
             string meetup = input.String("Meetup");

--- a/issues.wyam
+++ b/issues.wyam
@@ -312,6 +312,7 @@ public async Task<IEnumerable<IDocument>> GetIssueGitHubData(IReadOnlyList<IDocu
     string foundationReadme;
     using(HttpClient httpClient = new HttpClient())
 	{
+        httpClient.DefaultRequestHeaders.Add("User-Agent", "Discoverdot.net build process");
 		foundationReadme = await httpClient.GetStringAsync("https://raw.githubusercontent.com/dotnet/home/master/README.md");
 	}
 


### PR DESCRIPTION
Resolves #299.

## Problem

Sometimes web servers fail requests when the request contains no `User-Agent` header. Some sites use this as the default (which makes sense for security posture, I think).

However, this means Discover .NET can't load those sites because it will fail while attempting to read the RSS.

## What this PR Does

This PR sets a default `User-Agent` request header everywhere an `HttpClient` is used.

Every place where `HttpClient` is used, we add `.DefaultRequestHeaders.Add("User-Agent", "Discoverdot.net build process");`

This provides a user agent to the web host we're requesting against, resolving the issue.

## Screenshots

#### Before

The site being blocked: 

> ![the site being blocked](https://user-images.githubusercontent.com/2148318/55301351-2c3b4a00-540a-11e9-87bf-806dab0fcf17.png)


#### After

Now returning 200 OK with the User-Agent Header in place: 

> ![Now returning 200 OK with the User-Agent Header in Place](https://user-images.githubusercontent.com/2148318/55301389-69074100-540a-11e9-8dc2-bef1a53a0465.png)

The web site loading locally: 

> ![the web site loading locally](https://user-images.githubusercontent.com/2148318/55301329-0a41c780-540a-11e9-867a-e5b452ee7922.png)