### PR TITLE
Bump Wyam version from 2.1.3 --> 2.2.4

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -4,8 +4,8 @@
 // DISCOVERDOTNET_MEETUP_TOKEN
 // DISCOVERDOTNET_ALGOLIA_TOKEN
 
-#tool nuget:?package=Wyam&version=2.1.3
-#addin nuget:?package=Cake.Wyam&version=2.1.3
+#tool nuget:?package=Wyam&version=2.2.4
+#addin nuget:?package=Cake.Wyam&version=2.2.4
 #addin nuget:?package=NetlifySharp&version=0.1.0
 #addin nuget:?package=System.Runtime.Serialization.Formatters&version=4.3.0
 #addin nuget:?package=Algolia.Search&version=5.0.0


### PR DESCRIPTION
Noticed during #307. Figured I'd drop this here in case it could be helpful. Local build looked good on my end and I didn't notice anything different. 