### PR TITLE
Add NuGetTrends.com as project

### DIFF
--- a/input/data/projects/nuget-trends.yml
+++ b/input/data/projects/nuget-trends.yml
@@ -1,0 +1,12 @@
+Title: NuGet Trends
+Website: https://nugettrends.com/
+Description: Check out NuGet packages adoption and what's trending on NuGet.
+Image: https://nugettrends.com/assets/images/banner_social.png
+Source: https://github.com/NuGetTrends/nuget-trends
+Chat: https://gitter.im/NuGetTrends/Lobby
+Language: C#
+Tags:
+  - NuGet
+  - Trends
+  - Statistics
+DiscoveryDate: 8/3/2019


### PR DESCRIPTION
Please note I've ended up opening two PRs.
I'm unsure where's the best place to add it.
On one hand it's nice on _projects_ where it gets its page and it links to github and gitter, etc.

But it feels like a _resource_ somehow.

fuget.org is listed on _resources_ while baget is listed under _projects_.

In short, I guess this PR makes more sense and the second (#327) one for _resources_ could be closed then.