### PR TITLE
Remove sharpDox

### DIFF
--- a/input/data/projects/sharpdox.yml
+++ b/input/data/projects/sharpdox.yml
@@ -1,5 +1,0 @@
-Language: C#
-Source: https://github.com/Geaz/sharpDox
-Tags:
-  - Documentation
-DiscoveryDate: 9/14/2019


### PR DESCRIPTION
Its git repo says: "Discontinued - Use docFX as an alternative"