### PR TITLE
Add MySqlConnector

### DIFF
--- a/input/data/projects/mysqlconnector.yml
+++ b/input/data/projects/mysqlconnector.yml
@@ -1,0 +1,16 @@
+SourceCode: https://github.com/mysql-net/MySqlConnector
+NuGet:
+  - MySqlConnector
+  - MySqlConnector.Authentication.Ed25519
+  - MySqlConnector.Logging.log4net
+  - MySqlConnector.Logging.Microsoft.Extensions.Logging
+  - MySqlConnector.Logging.NLog
+  - MySqlConnector.Logging.Serilog
+Language: C#
+Image: https://mysqlconnector.net/img/logo.png
+Title: MySqlConnector
+Description: A truly async MySQL ADO.NET provider, supporting MySQL Server, MariaDB, Percona Server, Amazon Aurora, Azure Database for MySQL and more.
+Website: https://mysqlconnector.net/
+Twitter: mysqlconnector
+Tags:
+  - Data Access


### PR DESCRIPTION
This is not a duplicate of https://github.com/daveaglick/discoverdotnet/blob/master/data/projects/mysql-connector.yml

MySqlConnector is a MIT-licensed, clean-room implementation of an ADO.NET library for the MySQL protocol, that's developed in the open on GitHub. Oracle's Connector/NET is GPL, but uses GitHub to deliver code snapshots, not for OSS development.