### PR TITLE
Handle relative uri in RSS feed link #351

### DIFF
--- a/src/DiscoverDotnet/Models/FeedItem.cs
+++ b/src/DiscoverDotnet/Models/FeedItem.cs
@@ -17,10 +17,19 @@ namespace DiscoverDotnet.Models
         public IDictionary<string, string> Links { get; }
         public string Author { get; }
 
-        public FeedItem(ISyndicationItem item, DateTimeOffset recent)
+        public FeedItem(ISyndicationItem item, DateTimeOffset recent, Uri website)
         {
             Title = item.Title;
-            Link = item.Links.FirstOrDefault(x => x.RelationshipType == RssLinkTypes.Alternate)?.Uri.ToString() ?? item.Id;
+            ISyndicationLink firstLink = item.Links.FirstOrDefault(x => x.RelationshipType == RssLinkTypes.Alternate);
+            if (firstLink != null)
+            {
+                Link = firstLink.Uri.IsAbsoluteUri ? firstLink.Uri.AbsoluteUri : new Uri(website, firstLink.Uri).AbsoluteUri;
+            }
+            else
+            {
+                Link = item.Id;
+            }
+
             Published = item.Published != default ? item.Published : item.LastUpdated;
             Recent = Published > recent;
             Description = item.Description;

--- a/src/DiscoverDotnet/Modules/GetFeedData.cs
+++ b/src/DiscoverDotnet/Modules/GetFeedData.cs
@@ -35,7 +35,7 @@ namespace DiscoverDotnet.Modules
                 {
                     // Download the feed
                     context.LogInformation($"Getting feed for {feed}");
-                    string website = null;
+                    Uri website = null;
                     string title = null;
                     string author = null;
                     string description = null;
@@ -78,7 +78,7 @@ namespace DiscoverDotnet.Modules
 
                                                 case SyndicationElementType.Link:
                                                     ISyndicationLink link = await feedReader.ReadLink();
-                                                    website = link.Uri.ToString();
+                                                    website = link.Uri;
                                                     break;
 
                                                 case SyndicationElementType.Item:
@@ -118,7 +118,7 @@ namespace DiscoverDotnet.Modules
                     if (items.Count > 0)
                     {
                         FeedItem[] feedItems = items
-                            .Select(x => new FeedItem(x, _recent))
+                            .Select(x => new FeedItem(x, _recent, website))
                             .OrderByDescending(x => x.Published)
                             .Take(50) // Only take the 50 most recent items
                             .ToArray();
@@ -126,9 +126,9 @@ namespace DiscoverDotnet.Modules
                         metadata.Add("LastPublished", feedItems.First().Published);
                         metadata.Add("NewestFeedItem", feedItems[0]);
                     }
-                    if (!input.ContainsKey("Website") && !string.IsNullOrEmpty(website))
+                    if (!input.ContainsKey("Website") && website != null)
                     {
-                        metadata.Add("Website", website);
+                        metadata.Add("Website", website.ToString());
                     }
                     if (!input.ContainsKey("Title"))
                     {


### PR DESCRIPTION
I tried it with this xml file https://github.com/RemiBou/remibou.github.io/blob/master/temp.xml and it works. I launched the site generation with all the blogs and it seems that no other blog had this problem.

I couldn't find anything in the RSS spec about relative url resolution, it seems that using the link is okayish (https://cyber.harvard.edu/rss/relativeURI.html, http://www.rssboard.org/rss-profile).

