### PR TITLE
Fix image urls for unchase projects

### DIFF
--- a/data/projects/unchase-odata.yml
+++ b/data/projects/unchase-odata.yml
@@ -1,6 +1,6 @@
 Source: https://github.com/unchase/Unchase.Odata.Connectedservice
 Language: C#
-Image: https://unchase.gallerycdn.vsassets.io/extensions/unchase/unchaseodataconnectedservice/0.6.0/1564918339068/Microsoft.VisualStudio.Services.Icons.Default
+Image: https://raw.githubusercontent.com/unchase/Unchase.Odata.Connectedservice/master/src/Unchase.OData.ConnectedService/Resources/logo_128x128.png
 Title: Unchase OData Connected Service
 Description: A Visual Studio extension to generate C# (VB) client code for OData web service.
 Website: https://marketplace.visualstudio.com/items?itemName=Unchase.unchaseodataconnectedservice

--- a/data/projects/unchase-odata.yml
+++ b/data/projects/unchase-odata.yml
@@ -1,4 +1,4 @@
-Source: https://github.com/unchase/Unchase.Odata.Connectedservice
+SourceCode: https://github.com/unchase/Unchase.Odata.Connectedservice
 Language: C#
 Image: https://raw.githubusercontent.com/unchase/Unchase.Odata.Connectedservice/master/src/Unchase.OData.ConnectedService/Resources/logo_128x128.png
 Title: Unchase OData Connected Service

--- a/data/projects/unchase-open-api.yml
+++ b/data/projects/unchase-open-api.yml
@@ -1,4 +1,4 @@
-Source: https://github.com/unchase/Unchase.OpenAPI.Connectedservice
+SourceCode: https://github.com/unchase/Unchase.OpenAPI.Connectedservice
 Language: C#
 Image: https://raw.githubusercontent.com/unchase/Unchase.OpenAPI.Connectedservice/master/src/Resources/logo_128x128.png
 Title: Unchase OpenAPI (Swagger) Connected Service

--- a/data/projects/unchase-open-api.yml
+++ b/data/projects/unchase-open-api.yml
@@ -1,6 +1,6 @@
 Source: https://github.com/unchase/Unchase.OpenAPI.Connectedservice
 Language: C#
-Image: https://unchase.gallerycdn.vsassets.io/extensions/unchase/unchaseopenapiconnectedservice/1.3.0/1561821131419/Microsoft.VisualStudio.Services.Icons.Default
+Image: https://raw.githubusercontent.com/unchase/Unchase.OpenAPI.Connectedservice/master/src/Resources/logo_128x128.png
 Title: Unchase OpenAPI (Swagger) Connected Service
 Description: A Visual Studio extension to generate C# (TypeScript) HttpClient or (C# controllers) code for OpenAPI (formerly Swagger API) web service with NSwag.
 Website: https://marketplace.visualstudio.com/items?itemName=Unchase.unchaseopenapiconnectedservice


### PR DESCRIPTION
Hi, @daveaglick 

This PR fix image URLs and sources for [Unchase.Odata.Connectedservice](https://github.com/unchase/Unchase.Odata.Connectedservice) and [Unchase.OpenAPI.Connectedservice](https://github.com/unchase/Unchase.OpenAPI.Connectedservice) projects.

Thanks.
