### PR TITLE
Updated broken link to DirectSQL

### DIFF
--- a/data/projects/directsql.yml
+++ b/data/projects/directsql.yml
@@ -2,6 +2,6 @@ SourceCode: https://github.com/7k8m/DirectSQL
 NuGet:
   - DirectSQL
 Language: C#
-Docs: https://7k8m.github.io/DirectSQL.Document/doc/
+Docs: https://directsql.github.io/DirectSQL.Document/doc/
 Tags:
   - Data Access


### PR DESCRIPTION
Hi Dave,
The old link to the docs was broken. Proposing that the link for Docs : https://7k8m.github.io/DirectSQL.Document/doc/ be changed to https://directsql.github.io/DirectSQL.Document/doc/

The other links are fine.