### PR TITLE
Fix rss feed URL for blog.joaograssi.com

### DIFF
--- a/data/blogs/joaograssi.yml
+++ b/data/blogs/joaograssi.yml
@@ -1,3 +1,5 @@
-Feed: https://blog.joaograssi.com/rss/
+Feed: https://blog.joaograssi.com/rss
 Title: Joao Grassi's Blog
 Website: https://blog.joaograssi.com/
+Description: My errands in software development. Mostly .NET stuff, with a bit of front-end here and there.
+Author: Joao Grassi


### PR DESCRIPTION
After migrating to Hugo the `rss/` goes to a 404. Hugo doesn't seem to deal with it correctly =/. Hopefully this makes things working again. 

It still has an issue where the content type is `application/octet-stream` but without it, the url must contain the `.xml` extension which also sucks.

Thanks for keep this up and running :)